### PR TITLE
Performance improved, fixes and more

### DIFF
--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -12,6 +12,7 @@
   "nvim-cmp": { "branch": "main", "commit": "04e0ca376d6abdbfc8b52180f8ea236cbfddf782" },
   "nvim-lspconfig": { "branch": "master", "commit": "d67715d3b746a19e951b6b0a99663fa909bb9e64" },
   "nvim-treesitter": { "branch": "master", "commit": "4d76587eeca434a47f460fb7f1c900de49400688" },
+  "nvim-web-devicons": { "branch": "master", "commit": "6ed787740a3b275b748328eb2dc7dd22dae1c064" },
   "plenary.nvim": { "branch": "master", "commit": "f7adfc4b3f4f91aab6caebf42b3682945fbc35be" },
   "telescope-file-browser.nvim": { "branch": "master", "commit": "3bece973c5d80e7da447157822d5b0e73558d361" },
   "telescope.nvim": { "branch": "master", "commit": "d90956833d7c27e73c621a61f20b29fdb7122709" }

--- a/lazy-lock.json
+++ b/lazy-lock.json
@@ -5,7 +5,7 @@
   "cmp_luasnip": { "branch": "master", "commit": "05a9ab28b53f71d1aece421ef32fee2cb857a843" },
   "friendly-snippets": { "branch": "main", "commit": "dcd4a586439a1c81357d5b9d26319ae218cc9479" },
   "gitsigns.nvim": { "branch": "main", "commit": "078041e9d060a386b0c9d3a8c7a7b019a35d3fb0" },
-  "lazy.nvim": { "branch": "main", "commit": "83493db50a434a4c5c648faf41e2ead80f96e478" },
+  "lazy.nvim": { "branch": "main", "commit": "af6afefbb46ab29a8a1db69536b04290a9403876" },
   "mason-lspconfig.nvim": { "branch": "main", "commit": "2ba17cecfde8b8c7c7c287909a1e4de895223df6" },
   "mason.nvim": { "branch": "main", "commit": "3b5068f0fc565f337d67a2d315d935f574848ee7" },
   "nvim-autopairs": { "branch": "master", "commit": "dbfc1c34bed415906395db8303c71039b3a3ffb4" },

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -13,7 +13,7 @@ return {
         'rafamadriz/friendly-snippets',
     },
     lazy = true,
-    event = "BufReadPost",
+    event = "InsertEnter",
     config = function()
         -- [[ Configure nvim-cmp ]]
         -- See `:help cmp`

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -18,6 +18,7 @@ return {
         -- [[ Configure nvim-cmp ]]
         -- See `:help cmp`
         local cmp = require 'cmp'
+        local cmp_autopairs = require('nvim-autopairs.completion.cmp')
         local luasnip = require 'luasnip'
         require('luasnip.loaders.from_vscode').lazy_load()
         luasnip.config.setup {}
@@ -63,5 +64,8 @@ return {
                 { name = 'luasnip' },
             },
         }
+
+        -- Add parentheses after selecting function or method item
+        cmp.event:on('confirm_done', cmp_autopairs.on_confirm_done())
     end
 }

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -23,7 +23,50 @@ return {
         require('luasnip.loaders.from_vscode').lazy_load()
         luasnip.config.setup {}
 
+        local kind_icons = {
+            Text = "",
+            Method = "󰆧",
+            Function = "󰊕",
+            Constructor = "",
+            Field = "󰇽",
+            Variable = "󰂡",
+            Class = "󰠱",
+            Interface = "",
+            Module = "",
+            Property = "󰜢",
+            Unit = "",
+            Value = "󰎠",
+            Enum = "",
+            Keyword = "󰌋",
+            Snippet = "",
+            Color = "󰏘",
+            File = "󰈙",
+            Reference = "",
+            Folder = "󰉋",
+            EnumMember = "",
+            Constant = "󰏿",
+            Struct = "",
+            Event = "",
+            Operator = "󰆕",
+            TypeParameter = "󰅲",
+        }
+
         cmp.setup {
+            formatting = {
+                format = function(entry, vim_item)
+                    -- Kind icons
+                    vim_item.kind = string.format('%s %s', kind_icons[vim_item.kind], vim_item.kind) -- This concatenates the icons with the name of the item kind
+                    -- Source
+                    vim_item.menu = ({
+                        buffer = "[Buffer]",
+                        nvim_lsp = "[LSP]",
+                        luasnip = "[LuaSnip]",
+                        nvim_lua = "[Lua]",
+                        latex_symbols = "[LaTeX]",
+                    })[entry.source.name]
+                    return vim_item
+                end
+            },
             snippet = {
                 expand = function(args)
                     luasnip.lsp_expand(args.body)

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -13,7 +13,7 @@ return {
         'rafamadriz/friendly-snippets',
     },
     lazy = true,
-    event = "InsertEnter",
+    event = { "InsertEnter", "CmdlineEnter" },
     config = function()
         -- [[ Configure nvim-cmp ]]
         -- See `:help cmp`

--- a/lua/plugins/cmp.lua
+++ b/lua/plugins/cmp.lua
@@ -13,7 +13,7 @@ return {
         'rafamadriz/friendly-snippets',
     },
     lazy = true,
-    event = { "InsertEnter", "CmdlineEnter" },
+    event = "InsertEnter",
     config = function()
         -- [[ Configure nvim-cmp ]]
         -- See `:help cmp`

--- a/lua/plugins/gitsigns.lua
+++ b/lua/plugins/gitsigns.lua
@@ -1,7 +1,7 @@
 return {
     "lewis6991/gitsigns.nvim",
     lazy = true,
-    event = "BufReadPost",
+    event = { "BufReadPre", "BufNewfile" },
     opts = {},
     keys = {
         {

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -4,6 +4,8 @@ local lsp = require("utils.lsp")
 return {
     -- LSP Configuration & Plugins
     "neovim/nvim-lspconfig",
+    lazy = true,
+    event = { "BufReadPre", "BufNewFile" },
     dependencies = {
         -- Automatically install LSPs to stdpath for neovim
         {
@@ -11,11 +13,10 @@ return {
             dependencies = {
                 { "williamboman/mason-lspconfig.nvim", opts = {} },
             },
+            build = ":MasonUpdate",
             opts = {},
         },
     },
-    lazy = true,
-    event = "BufReadPost",
     config = function()
         -- [[ Configure LSP ]]
         --  This function gets run when an LSP connects to a particular buffer.

--- a/lua/plugins/lspconfig.lua
+++ b/lua/plugins/lspconfig.lua
@@ -56,6 +56,7 @@ return {
 
         local mason_lspconfig = require "mason-lspconfig"
 
+        require("mason").setup()
         mason_lspconfig.setup {
             ensure_installed = vim.tbl_keys(lsp.servers),
         }

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -3,7 +3,8 @@ return {
     tag = "0.1.5",
     dependencies = {
         "nvim-lua/plenary.nvim",
-        "nvim-telescope/telescope-file-browser.nvim"
+        "nvim-telescope/telescope-file-browser.nvim",
+        "nvim-tree/nvim-web-devicons"
     },
     lazy = true,
     cmd = "Telescope",

--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -6,7 +6,7 @@ return {
         "nvim-telescope/telescope-file-browser.nvim"
     },
     lazy = true,
-    event = "VeryLazy",
+    cmd = "Telescope",
     keys = {
         {
             "<leader>ff",

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,7 +1,7 @@
 return {
     "nvim-treesitter/nvim-treesitter",
     lazy = true,
-    event = "VeryLazy",
+    event = { "BufReadPre", "BufNewFile" },
     build = ":TSUpdate",
     config = function()
         vim.defer_fn(function()


### PR DESCRIPTION
- chore(nvim): lazy.nvim update
- perf(nvim): load telescope via cmd or keys
- perf(nvim): load gitsigns on read buffer
- perf(nvim): load lsp on read buffer event
- perf(nvim): load cmp on InsertEnter event
- perf(nvim): load treesitter on buffer read event
- chore(mason): ensure its setup before mason-lspconfig
- feat(cmp): add parentheses after selecting function or method item
- perf(nvim): load cmp on Insert/CmdlineEnter event
- Revert "perf(nvim): load cmp on Insert/CmdlineEnter event"
- feat(cmp): lsp kind icons
- feat(plugin): nvim-web-devicons
